### PR TITLE
Add DataSyncer Controller + E2E tests

### DIFF
--- a/.github/workflows/e2e-datasyncer.yaml
+++ b/.github/workflows/e2e-datasyncer.yaml
@@ -1,0 +1,54 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'pkg/test/e2e/suite/**'
+      - 'pkg/test/e2e/datasyncer/**'
+      - 'pkg/controllers/datasyncer/**'
+      - '.github/workflows/e2e-datasyncer.yaml'
+
+jobs:
+  e2e:
+    name: Run DataSyncer Controller
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out your repository
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Go (adjust version as needed)
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.1'
+
+      # Install Kind 
+      - name: Install Kind
+        run: |
+          # For AMD64 / x86_64
+          [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+          # For ARM64
+          [ $(uname -m) = aarch64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-arm64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      # Create Kind cluster
+      - name: Create Kind cluster
+        run: kind create cluster --name kubeflag-e2e --wait 120s
+
+
+      # Run the E2E suite
+      - name: Run Ginkgo E2E tests
+        run: |
+          kind get kubeconfig --name kubeflag-e2e > kubeconfig
+          export KUBECONFIG=$PWD/kubeconfig
+          kubectl create -f config/crd/bases/
+          go test ./pkg/test/e2e/datasyncer/... -tags=e2e -v
+
+      # Tear down cluster to free resources
+      - name: Delete Kind cluster
+        if: always()
+        run: kind delete cluster --name kubeflag-e2e

--- a/cmd/controller-manager/app/controllers.go
+++ b/cmd/controller-manager/app/controllers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflag/kubeflag/cmd/controller-manager/app/options"
 	challengecontroller "github.com/kubeflag/kubeflag/pkg/controllers/challenge"
 	instancecontroller "github.com/kubeflag/kubeflag/pkg/controllers/challengeinstance"
+	datasynccontroller "github.com/kubeflag/kubeflag/pkg/controllers/datasyncer"
 )
 
 type controllerCreator func(*options.ControllerContext) error
@@ -32,6 +33,7 @@ type controllerCreator func(*options.ControllerContext) error
 var AllControllers = map[string]controllerCreator{
 	challengecontroller.ControllerName: createChallengeController,
 	instancecontroller.ControllerName:  createInstanceController,
+	datasynccontroller.ControllerName:  createDataSyncController,
 }
 
 func createAllControllers(ctrlCtx *options.ControllerContext) error {
@@ -50,4 +52,8 @@ func createChallengeController(ctrlCtx *options.ControllerContext) error {
 
 func createInstanceController(ctrlCtx *options.ControllerContext) error {
 	return instancecontroller.Add(ctrlCtx.Ctx, ctrlCtx.Mgr, 1, nil)
+}
+
+func createDataSyncController(ctrlCtx *options.ControllerContext) error {
+	return datasynccontroller.Add(ctrlCtx.Ctx, ctrlCtx.Mgr, 1, ctrlCtx.Log)
 }

--- a/example/challenge.yaml
+++ b/example/challenge.yaml
@@ -17,6 +17,9 @@ kind: Challenge
 metadata:
   name: web-1
 spec:
+  secretReferences:
+    - name: web
+      namespace: default 
   defaultTTL: 5m
   template:
     spec:

--- a/pkg/controllers/datasyncer/controller.go
+++ b/pkg/controllers/datasyncer/controller.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2025 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datasyncer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kubeflag/kubeflag/pkg/controllers/challenge"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type DataSyncerReconciler struct {
+	ctrlruntimeclient.Client
+	log      logr.Logger
+	recorder record.EventRecorder
+}
+
+const ControllerName = "datasyncer-controller"
+
+// Add creates a new Challenge controller and adds it to the Manager.
+func Add(ctx context.Context, mgr manager.Manager, numWorkers int, log *logr.Logger) error {
+	reconciler := &DataSyncerReconciler{
+		Client:   mgr.GetClient(),
+		log:      log.WithName(ControllerName),
+		recorder: mgr.GetEventRecorderFor(ControllerName),
+	}
+
+	// Define a predicate to filter resources with the annotation
+	annotatedResourcesPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return challenge.HasChallengesAnnotation(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return challenge.HasChallengesAnnotation(e.ObjectNew)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return challenge.HasChallengesAnnotation(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return challenge.HasChallengesAnnotation(e.Object)
+		},
+	}
+
+	// Set up the controller with the reconciler
+	_, err := builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(&corev1.Secret{}).
+		WithEventFilter(annotatedResourcesPredicate). // Add predicate to filter events
+		Watches(
+			&corev1.ConfigMap{}, // Watch ConfigMaps
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(annotatedResourcesPredicate), // Add predicate for ConfigMaps
+		).
+		Build(reconciler)
+
+	return err
+}
+
+func (r *DataSyncerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	r.log.WithValues("resource", req.NamespacedName)
+	// Attempt to fetch the resource as a Secret
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, secret); err == nil {
+		r.log.Info("Reconciling Secret", "name", secret.Name, "namespace", secret.Namespace)
+		return r.reconcileSecret(ctx, secret)
+	}
+
+	// If it's not a Secret, attempt to fetch it as a ConfigMap
+	configMap := &corev1.ConfigMap{}
+	if err := r.Get(ctx, req.NamespacedName, configMap); err == nil {
+		r.log.Info("Reconciling ConfigMap", "name", configMap.Name, "namespace", configMap.Namespace)
+		return r.reconcileConfigMap(ctx, configMap)
+	}
+
+	// If neither, log an error
+	r.log.Error(fmt.Errorf("resource is neither Secret nor ConfigMap"), "Invalid resource type", "name", req.Name, "namespace", req.Namespace)
+	return reconcile.Result{}, nil
+}
+
+// Helper to reconcile a Secret.
+func (r *DataSyncerReconciler) reconcileSecret(ctx context.Context, secret *corev1.Secret) (reconcile.Result, error) {
+	// Parse annotation and sync to target namespaces
+	challengeNames, err := getChallengeNamesFromAnnotation(secret)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to parse challenges annotation: %w", err)
+	}
+	for _, challengeName := range challengeNames {
+		if err := r.syncSecretToNamespace(ctx, secret, challengeName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to sync secret to namespace %s: %w", challengeName, err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+// Helper to reconcile a ConfigMap.
+func (r *DataSyncerReconciler) reconcileConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (reconcile.Result, error) {
+	// Parse annotation and sync to target namespaces
+	challengeNames, err := getChallengeNamesFromAnnotation(configMap)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to parse challenges annotation: %w", err)
+	}
+	for _, challengeName := range challengeNames {
+		if err := r.syncConfigMapToNamespace(ctx, configMap, challengeName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to sync configmap to namespace %s: %w", challengeName, err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *DataSyncerReconciler) syncSecretToNamespace(ctx context.Context, secret *corev1.Secret, targetNamespace string) error {
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secret.Name,
+			Namespace: targetNamespace,
+		},
+		Data:       secret.Data,
+		StringData: secret.StringData,
+		Type:       secret.Type,
+	}
+	return r.createOrUpdate(ctx, newSecret)
+}
+
+func (r *DataSyncerReconciler) syncConfigMapToNamespace(ctx context.Context, configMap *corev1.ConfigMap, targetNamespace string) error {
+	newConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMap.Name,
+			Namespace: targetNamespace,
+		},
+		Data:       configMap.Data,
+		BinaryData: configMap.BinaryData,
+	}
+	return r.createOrUpdate(ctx, newConfigMap)
+}
+
+func (r *DataSyncerReconciler) createOrUpdate(ctx context.Context, obj ctrlruntimeclient.Object) error {
+	r.log.Info("Syncing the data object", "object", obj.GetObjectKind())
+	err := r.Create(ctx, obj)
+	if err != nil && apierrors.IsAlreadyExists(err) {
+		return r.Update(ctx, obj)
+	}
+	return err
+}
+
+// Helper to parse challenge names from annotation.
+func getChallengeNamesFromAnnotation(obj ctrlruntimeclient.Object) ([]string, error) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return nil, fmt.Errorf("no annotations found")
+	}
+	annotationValue, exists := annotations[challenge.DataObjectAnnotationKey]
+	if !exists {
+		return nil, fmt.Errorf("no challenges annotation found")
+	}
+	var challengeNames []string
+	if err := json.Unmarshal([]byte(annotationValue), &challengeNames); err != nil {
+		return nil, fmt.Errorf("failed to parse challenges annotation: %w", err)
+	}
+	return challengeNames, nil
+}

--- a/pkg/test/e2e/datasyncer/datasyncer_e2e_test.go
+++ b/pkg/test/e2e/datasyncer/datasyncer_e2e_test.go
@@ -1,0 +1,231 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2025 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datasyncer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeflag/kubeflag/pkg/controllers/challenge"
+	datasyncercontroller "github.com/kubeflag/kubeflag/pkg/controllers/datasyncer"
+	kubeflaglog "github.com/kubeflag/kubeflag/pkg/log"
+	"github.com/kubeflag/kubeflag/pkg/test/e2e/suite"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	mgr       manager.Manager
+	cfg       *rest.Config
+	log       = kubeflaglog.NewDefault()
+)
+
+// Ginkgo entry point
+func TestDataSyncerE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DataSyncer Controller E2E Suite")
+}
+
+// Bootstraps a real manager and client against the Kind cluster.
+var _ = BeforeSuite(func() {
+	mgr, ctx, cancel = suite.Bootstrap()
+
+	// Run controller inside a goroutine.
+	go func() {
+		defer GinkgoRecover()
+		Expect(datasyncercontroller.Add(ctx, mgr, 1, &log)).To(Succeed())
+		Expect(mgr.Start(ctx)).To(Succeed())
+	}()
+
+	k8sClient = mgr.GetClient()
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	suite.Teardown(cancel)
+})
+
+// newTokenSecret creates a Kubernetes Secret with token data and annotation
+func newTokenSecret(name, challengeName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Annotations: map[string]string{
+				challenge.DataObjectAnnotationKey: fmt.Sprintf(`["%s"]`, challengeName),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"token": []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+		},
+	}
+}
+
+func newConfigMap(name, challengeName string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default", // or the source namespace
+			Annotations: map[string]string{
+				challenge.DataObjectAnnotationKey: fmt.Sprintf(`["%s"]`, challengeName),
+			},
+		},
+		Data: map[string]string{
+			"token": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+	}
+}
+
+var _ = Describe("Secret Synchronization E2E", func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 2 * time.Second
+	)
+
+	It("keeps the synced Secret updated", func() {
+		name := fmt.Sprintf("secret-%d", time.Now().UnixNano())
+		challengeName := fmt.Sprintf("chal-%s", name)
+
+		secret := newTokenSecret(name, challengeName)
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: challengeName}}
+
+		By("creating the Challenge namespace")
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, secret)
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		By("waiting for namespace to be Active")
+		Eventually(func() (corev1.NamespacePhase, error) {
+			var got corev1.Namespace
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: challengeName}, &got); err != nil {
+				return "", err
+			}
+			return got.Status.Phase, nil
+		}, timeout, interval).Should(Equal(corev1.NamespaceActive))
+
+		By("creating the source Secret")
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+		By("verifying the Secret is replicated")
+		Eventually(func() (string, error) {
+			var sec corev1.Secret
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: challengeName}, &sec); err != nil {
+				return "", err
+			}
+			return string(sec.Data["token"]), nil
+		}, timeout, interval).Should(Equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+
+		By("updating the source Secret")
+		secret.Data["token"] = []byte("1234567890")
+		Expect(k8sClient.Update(ctx, secret)).To(Succeed())
+
+		By("verifying the update is synced")
+		Eventually(func() (string, error) {
+			var sec corev1.Secret
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: challengeName}, &sec); err != nil {
+				return "", err
+			}
+			return string(sec.Data["token"]), nil
+		}, timeout, interval).Should(Equal("1234567890"))
+	})
+})
+
+var _ = Describe("ConfigMap Synchronization E2E", func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 2 * time.Second
+	)
+
+	It("Normal Sync: Create + Update", func() {
+		name := fmt.Sprintf("configmap-%d", time.Now().UnixNano())
+		challengeName := fmt.Sprintf("chal-for-%s", name)
+
+		cm := newConfigMap(name, challengeName)
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: challengeName,
+			},
+		}
+
+		By("creating the Challenge namespace")
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cm)
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		By("waiting for the namespace to be Active")
+		Eventually(func() (corev1.NamespacePhase, error) {
+			var got corev1.Namespace
+			if err := k8sClient.Get(ctx, client.ObjectKey{Name: challengeName}, &got); err != nil {
+				return "", err
+			}
+			return got.Status.Phase, nil
+		}, timeout, interval).Should(Equal(corev1.NamespaceActive))
+
+		By("creating the source ConfigMap")
+		Expect(k8sClient.Create(ctx, cm)).To(Succeed())
+		By("waiting for the ConfigMap to be synced")
+		Eventually(func() (string, error) {
+			var synced corev1.ConfigMap
+			if err := k8sClient.Get(
+				ctx,
+				client.ObjectKey{Name: name, Namespace: challengeName},
+				&synced,
+			); err != nil {
+				return "", err
+			}
+			return synced.Data["token"], nil
+		}, timeout, interval).Should(Equal("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+
+		By("updating the ConfigMap")
+		cm.Data["token"] = "1234567890"
+		Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+		By("waiting for the updated ConfigMap to be synced")
+		Eventually(func() (string, error) {
+			var synced corev1.ConfigMap
+			if err := k8sClient.Get(
+				ctx,
+				client.ObjectKey{Name: name, Namespace: challengeName},
+				&synced,
+			); err != nil {
+				return "", err
+			}
+			return synced.Data["token"], nil
+		}, timeout, interval).Should(Equal("1234567890"))
+	})
+})


### PR DESCRIPTION
This PR adds the foundation of DataSyncer Controller, the controller that will be responsible for syncing the secrets and configmaps into the challenge instances' namespaces. 

Fixes #7 