### PR TITLE
Re-implement datasyncer with interfaces

### DIFF
--- a/pkg/controllers/challenge/controller.go
+++ b/pkg/controllers/challenge/controller.go
@@ -127,7 +127,7 @@ func (r *ChallengeReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	// Add finalizer if not present
 	if challenge.GetDeletionTimestamp() == nil && !kubernetes.HasFinalizer(challenge, ChallengeInstanceFinalizer) {
 		kubernetes.AddFinalizer(challenge, ChallengeInstanceFinalizer)
-		if err := r.Update(ctx, challenge); err != nil {
+		if err = r.Update(ctx, challenge); err != nil {
 			r.log.Error(err, "Failed to add finalizer to Challenge")
 			return reconcile.Result{}, err
 		}
@@ -144,19 +144,19 @@ func (r *ChallengeReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	challenge.Status.Healthy = healthy
 
 	// Update Challenge status if needed
-	if err := r.updateStatus(ctx, challenge); err != nil {
+	if err = r.updateStatus(ctx, challenge); err != nil {
 		r.log.Error(err, "Failed to update Challenge status")
 		return reconcile.Result{}, err
 	}
 
 	// Reconcile the namespace
-	if err := r.reconcileNamespace(ctx, challenge); err != nil {
+	if err = r.reconcileNamespace(ctx, challenge); err != nil {
 		r.log.Error(err, "Failed to reconcile Namespace")
 		return reconcile.Result{}, err
 	}
 
 	r.log.V(1).Info("Reconciling the References")
-	if err := r.reconcileReferences(ctx, challenge); err != nil {
+	if err = r.reconcileReferences(ctx, challenge); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllers/datasyncer/controller.go
+++ b/pkg/controllers/datasyncer/controller.go
@@ -18,8 +18,6 @@ package datasyncer
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -27,12 +25,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -45,7 +41,13 @@ type DataSyncerReconciler struct {
 	recorder record.EventRecorder
 }
 
-const ControllerName = "datasyncer-controller"
+const (
+	ControllerName   = "datasyncer-controller"
+	ManagedLabel     = "datasyncer.kubeflag.io/managed"
+	SourceLabel      = "datasyncer.kubeflag.io/source"
+	CleanupFinalizer = "datasyncer.kubeflag.io/cleanup-synced-objects"
+	SyncFinalizer    = "datasyncer.kubeflag.io/synced"
+)
 
 // Add creates a new Challenge controller and adds it to the Manager.
 func Add(ctx context.Context, mgr manager.Manager, numWorkers int, log *logr.Logger) error {
@@ -55,34 +57,28 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, log *logr.Log
 		recorder: mgr.GetEventRecorderFor(ControllerName),
 	}
 
-	// Define a predicate to filter resources with the annotation
-	annotatedResourcesPredicate := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return challenge.HasChallengesAnnotation(e.Object)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return challenge.HasChallengesAnnotation(e.ObjectNew)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return challenge.HasChallengesAnnotation(e.Object)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return challenge.HasChallengesAnnotation(e.Object)
-		},
-	}
+	// Predicate: has Challenge annotation
+	hasChallengeAnno := predicate.NewPredicateFuncs(func(obj ctrlruntimeclient.Object) bool {
+		return challenge.HasChallengesAnnotation(obj)
+	})
 
-	// Set up the controller with the reconciler
+	// Predicate: has managed label
+	hasManagedLabel := predicate.NewPredicateFuncs(func(obj ctrlruntimeclient.Object) bool {
+		return obj.GetLabels()[ManagedLabel] == "true"
+	})
+
+	// OR: either annotated or managed
+	sourceOrCopyPredicate := predicate.Or(hasChallengeAnno, hasManagedLabel)
+
+	// Build controller: watch Secrets and ConfigMaps matching either predicate
 	_, err := builder.ControllerManagedBy(mgr).
 		Named(ControllerName).
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: numWorkers,
-		}).
-		For(&corev1.Secret{}).
-		WithEventFilter(annotatedResourcesPredicate). // Add predicate to filter events
+		WithOptions(controller.Options{MaxConcurrentReconciles: numWorkers}).
+		For(&corev1.Secret{}, builder.WithPredicates(sourceOrCopyPredicate)).
 		Watches(
-			&corev1.ConfigMap{}, // Watch ConfigMaps
+			&corev1.ConfigMap{},
 			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(annotatedResourcesPredicate), // Add predicate for ConfigMaps
+			builder.WithPredicates(sourceOrCopyPredicate),
 		).
 		Build(reconciler)
 
@@ -91,78 +87,15 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, log *logr.Log
 
 func (r *DataSyncerReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	r.log.WithValues("resource", req.NamespacedName)
-	// Attempt to fetch the resource as a Secret
+	// Try Secret first
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, req.NamespacedName, secret); err == nil {
-		r.log.Info("Reconciling Secret", "name", secret.Name, "namespace", secret.Namespace)
-		return r.reconcileSecret(ctx, secret)
-	}
-
-	// If it's not a Secret, attempt to fetch it as a ConfigMap
-	configMap := &corev1.ConfigMap{}
-	if err := r.Get(ctx, req.NamespacedName, configMap); err == nil {
-		r.log.Info("Reconciling ConfigMap", "name", configMap.Name, "namespace", configMap.Namespace)
-		return r.reconcileConfigMap(ctx, configMap)
-	}
-
-	// If neither, log an error
-	r.log.Error(fmt.Errorf("resource is neither Secret nor ConfigMap"), "Invalid resource type", "name", req.Name, "namespace", req.Namespace)
-	return reconcile.Result{}, nil
-}
-
-// Helper to reconcile a Secret.
-func (r *DataSyncerReconciler) reconcileSecret(ctx context.Context, secret *corev1.Secret) (reconcile.Result, error) {
-	// Parse annotation and sync to target namespaces
-	challengeNames, err := getChallengeNamesFromAnnotation(secret)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to parse challenges annotation: %w", err)
-	}
-	for _, challengeName := range challengeNames {
-		if err := r.syncSecretToNamespace(ctx, secret, challengeName); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to sync secret to namespace %s: %w", challengeName, err)
-		}
+		r.log.Info("Reconciling Secret", "name", secret.Name)
+		return r.reconcileDataObject(ctx, SecretWrapper{secret})
+	} else if !apierrors.IsNotFound(err) {
+		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
-}
-
-// Helper to reconcile a ConfigMap.
-func (r *DataSyncerReconciler) reconcileConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (reconcile.Result, error) {
-	// Parse annotation and sync to target namespaces
-	challengeNames, err := getChallengeNamesFromAnnotation(configMap)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to parse challenges annotation: %w", err)
-	}
-	for _, challengeName := range challengeNames {
-		if err := r.syncConfigMapToNamespace(ctx, configMap, challengeName); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to sync configmap to namespace %s: %w", challengeName, err)
-		}
-	}
-	return reconcile.Result{}, nil
-}
-
-func (r *DataSyncerReconciler) syncSecretToNamespace(ctx context.Context, secret *corev1.Secret, targetNamespace string) error {
-	newSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      secret.Name,
-			Namespace: targetNamespace,
-		},
-		Data:       secret.Data,
-		StringData: secret.StringData,
-		Type:       secret.Type,
-	}
-	return r.createOrUpdate(ctx, newSecret)
-}
-
-func (r *DataSyncerReconciler) syncConfigMapToNamespace(ctx context.Context, configMap *corev1.ConfigMap, targetNamespace string) error {
-	newConfigMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configMap.Name,
-			Namespace: targetNamespace,
-		},
-		Data:       configMap.Data,
-		BinaryData: configMap.BinaryData,
-	}
-	return r.createOrUpdate(ctx, newConfigMap)
 }
 
 func (r *DataSyncerReconciler) createOrUpdate(ctx context.Context, obj ctrlruntimeclient.Object) error {
@@ -172,21 +105,4 @@ func (r *DataSyncerReconciler) createOrUpdate(ctx context.Context, obj ctrlrunti
 		return r.Update(ctx, obj)
 	}
 	return err
-}
-
-// Helper to parse challenge names from annotation.
-func getChallengeNamesFromAnnotation(obj ctrlruntimeclient.Object) ([]string, error) {
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		return nil, fmt.Errorf("no annotations found")
-	}
-	annotationValue, exists := annotations[challenge.DataObjectAnnotationKey]
-	if !exists {
-		return nil, fmt.Errorf("no challenges annotation found")
-	}
-	var challengeNames []string
-	if err := json.Unmarshal([]byte(annotationValue), &challengeNames); err != nil {
-		return nil, fmt.Errorf("failed to parse challenges annotation: %w", err)
-	}
-	return challengeNames, nil
 }

--- a/pkg/controllers/datasyncer/helper.go
+++ b/pkg/controllers/datasyncer/helper.go
@@ -1,0 +1,62 @@
+package datasyncer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kubeflag/kubeflag/pkg/controllers/challenge"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Helper to parse challenge names from annotation.
+func getChallengeNamesFromAnnotation(obj ctrlruntimeclient.Object) ([]string, error) {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return nil, fmt.Errorf("no annotations found")
+	}
+	annotationValue, exists := annotations[challenge.DataObjectAnnotationKey]
+	if !exists {
+		return nil, fmt.Errorf("no challenges annotation found")
+	}
+	var challengeNames []string
+	if err := json.Unmarshal([]byte(annotationValue), &challengeNames); err != nil {
+		return nil, fmt.Errorf("failed to parse challenges annotation: %w", err)
+	}
+	return challengeNames, nil
+}
+
+func isSource(object ctrlruntimeclient.Object) bool {
+	// Retrieve labels from the object
+	labels := object.GetLabels()
+
+	// Check if both conditions are satisfied to determine if it's not a source
+	if labels != nil {
+		// Check if the label "DataSyncLabelKey" exists and its value is "true"
+		if value, labelExists := labels[ManagedLabel]; labelExists && value == "true" {
+			// Check if the label "datasyncer.kubeflag.io/source" exists
+			if _, sourceLabelExists := labels[SourceLabel]; sourceLabelExists {
+				return false // Not a source if both conditions are met
+			}
+		}
+	}
+
+	// If either condition is not met, the object is a source
+	return true
+}
+
+func getSource(object ctrlruntimeclient.Object) *types.NamespacedName {
+	labels := object.GetLabels()
+	if labels != nil {
+		if value, labelExists := labels[SourceLabel]; labelExists {
+			name := strings.Split(value, "---")[1]
+			namespace := strings.Split(value, "---")[0]
+			return &types.NamespacedName{
+				Name:      name,
+				Namespace: namespace,
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/controllers/datasyncer/interface.go
+++ b/pkg/controllers/datasyncer/interface.go
@@ -1,0 +1,265 @@
+package datasyncer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kubeflag/kubeflag/pkg/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type SyncableObject interface {
+	ctrlruntimeclient.Object
+	GetData() map[string][]byte
+	SetData(map[string][]byte)
+	GetTypeMeta() metav1.TypeMeta
+	GetBaseObject() ctrlruntimeclient.Object
+}
+
+type SecretWrapper struct {
+	*corev1.Secret
+}
+
+func (s SecretWrapper) GetData() map[string][]byte {
+	return s.Data
+}
+func (s SecretWrapper) SetData(d map[string][]byte) {
+	s.Data = d
+}
+func (s SecretWrapper) GetTypeMeta() metav1.TypeMeta {
+	return s.TypeMeta
+}
+
+type ConfigMapWrapper struct {
+	*corev1.ConfigMap
+}
+
+func (s SecretWrapper) GetBaseObject() ctrlruntimeclient.Object    { return s.Secret }
+func (c ConfigMapWrapper) GetBaseObject() ctrlruntimeclient.Object { return c.ConfigMap }
+
+func (c ConfigMapWrapper) GetData() map[string][]byte {
+	// Convert string -> []byte for unified comparison
+	data := make(map[string][]byte, len(c.Data))
+	for k, v := range c.Data {
+		data[k] = []byte(v)
+	}
+	return data
+}
+func (c ConfigMapWrapper) SetData(d map[string][]byte) {
+	// Convert []byte -> string
+	cmData := make(map[string]string, len(d))
+	for k, v := range d {
+		cmData[k] = string(v)
+	}
+	c.Data = cmData
+}
+func (c ConfigMapWrapper) GetTypeMeta() metav1.TypeMeta {
+	return c.TypeMeta
+}
+
+func (r *DataSyncerReconciler) reconcileDataObject(ctx context.Context, obj SyncableObject) (reconcile.Result, error) {
+	if isSource(obj) {
+		challengesNames, err := getChallengeNamesFromAnnotation(obj)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("failed to parse annotations: %w", err)
+		}
+
+		if err = r.cleanupUndesiredCopies(ctx, obj, challengesNames); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if obj.GetDeletionTimestamp() != nil && kubernetes.HasFinalizer(obj, CleanupFinalizer) {
+			if len(challengesNames) > 0 {
+				if err = r.cleanupCopies(ctx, obj, challengesNames); err != nil {
+					return reconcile.Result{}, err
+				}
+			}
+
+			kubernetes.RemoveFinalizer(obj, CleanupFinalizer)
+			if err = r.Update(ctx, obj); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
+
+		for _, challengeName := range challengesNames {
+			if err = r.syncToNamespace(ctx, obj, challengeName); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to sync secret to namespace %s: %w", challengeName, err)
+			}
+			if !kubernetes.HasFinalizer(obj, CleanupFinalizer) {
+				kubernetes.AddFinalizer(obj, CleanupFinalizer)
+				if err = r.Update(ctx, obj); err != nil {
+					return reconcile.Result{}, err
+				}
+			}
+		}
+
+	} else {
+		var source ctrlruntimeclient.Object
+		switch obj.(type) {
+		case SecretWrapper:
+			source = &corev1.Secret{}
+		}
+		namespaced := getSource(obj)
+		if namespaced == nil {
+			return reconcile.Result{}, fmt.Errorf("secret don't have any source obeject")
+		}
+		fmt.Println(namespaced.Name, namespaced.Namespace)
+		if err := r.Get(ctx, *namespaced, source); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// If object is deleted now, reconcile the source to create another one if it's necessary.
+		if obj.GetDeletionTimestamp() != nil && kubernetes.HasAnyFinalizer(obj, SyncFinalizer) {
+			annotations := source.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations["datasyncer.kubeflag.io/last-trigger"] = time.Now().Format(time.RFC3339)
+
+			source.SetAnnotations(annotations)
+			if err := r.Update(ctx, source); err != nil {
+				return reconcile.Result{}, err
+			}
+			kubernetes.RemoveFinalizer(obj, SyncFinalizer)
+			if err := r.Update(ctx, obj.GetBaseObject()); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to remove finalizer in object %w", err)
+			}
+			return reconcile.Result{}, nil
+		}
+		var syncable SyncableObject
+		switch s := source.(type) {
+		case *corev1.Secret:
+			syncable = &SecretWrapper{Secret: s}
+		case *corev1.ConfigMap:
+			syncable = &ConfigMapWrapper{ConfigMap: s}
+		default:
+			return reconcile.Result{}, fmt.Errorf("unsupported source type: %T", source)
+		}
+
+		if !equality.Semantic.DeepEqual(syncable.GetData(), obj.GetData()) {
+			obj.SetData(syncable.GetData())
+			return reconcile.Result{}, r.Update(ctx, obj)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *DataSyncerReconciler) syncToNamespace(ctx context.Context, source SyncableObject, targetNamespace string) error {
+	var newObj ctrlruntimeclient.Object
+	switch source.(type) {
+	case SecretWrapper:
+		newObj = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      source.GetName(),
+				Namespace: targetNamespace,
+				Labels: map[string]string{
+					ManagedLabel: "true",
+					SourceLabel:  fmt.Sprintf("%s---%s", source.GetNamespace(), source.GetName()),
+				},
+				Finalizers: []string{SyncFinalizer},
+			},
+			Data: source.GetData(),
+		}
+	case ConfigMapWrapper:
+		newObj = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      source.GetName(),
+				Namespace: targetNamespace,
+				Labels: map[string]string{
+					ManagedLabel: "true",
+					SourceLabel:  fmt.Sprintf("%s---%s", source.GetNamespace(), source.GetName()),
+				},
+				Finalizers: []string{SyncFinalizer},
+			},
+			BinaryData: source.GetData(),
+		}
+	}
+
+	return r.createOrUpdate(ctx, newObj)
+}
+
+func (r *DataSyncerReconciler) cleanupCopies(ctx context.Context, source SyncableObject, challenges []string) error {
+	// Build a set for quick membership tests
+	desired := sets.NewString(challenges...)
+
+	for _, ns := range desired.List() {
+		var copy ctrlruntimeclient.Object
+		switch source.(type) {
+		case SecretWrapper:
+			copy = &corev1.Secret{}
+		}
+		key := types.NamespacedName{Name: source.GetGenerateName(), Namespace: ns}
+
+		err := r.Get(ctx, key, copy)
+		if apierrors.IsNotFound(err) {
+			// nothing to delete in this namespace
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to get %s %s/%s: %w", source.GetTypeMeta().Kind, ns, source.GetName(), err)
+		}
+
+		// Optional safety check: ensure it is a managed copy
+		if copy.GetLabels() != nil && copy.GetLabels()[ManagedLabel] != "true" {
+			continue
+		}
+
+		if err := r.Delete(ctx, copy); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete %s %s/%s: %w", source.GetTypeMeta().Kind, ns, source.GetName(), err)
+		}
+	}
+	return nil
+}
+
+func (r *DataSyncerReconciler) cleanupUndesiredCopies(ctx context.Context, source SyncableObject, desiredNamespaces []string) error {
+	// Fast membership check
+	desired := sets.NewString(desiredNamespaces...)
+
+	selector := ctrlruntimeclient.MatchingLabels{
+		ManagedLabel: "true",
+		SourceLabel:  fmt.Sprintf("%s---%s", source.GetNamespace(), source.GetName()),
+	}
+
+	var list ctrlruntimeclient.ObjectList
+	switch source.(type) {
+	case SecretWrapper:
+		list = &corev1.SecretList{}
+	}
+
+	if err := r.List(ctx, list, selector); err != nil {
+		return fmt.Errorf("list managed copies: %w", err)
+	}
+
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return fmt.Errorf("extract list items: %w", err)
+	}
+
+	for _, s := range items {
+		// ✨ Convert to client.Object (has GetName()/GetNamespace())
+		obj, ok := s.(ctrlruntimeclient.Object)
+		if !ok {
+			return fmt.Errorf("failt to convert runtime.Object to ctrlruntimeclient.Object")
+		}
+		if desired.Has(obj.GetNamespace()) {
+			continue // still wanted
+		}
+
+		// Delete copies in namespaces no longer desired
+		if err := r.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete stale copy %s/%s: %w", obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The current controller is missing a lot of cases. What will happen if the copied object is deleted or updated?? 

Nothing will happen, because we keep watching the sources only, and we cannot trigger events if the copied objects have an event! 

This PR improves the reconciliation logic of this controller by watching the sources and copied objects! 

* If a copied object is updated, we check the source and make sure that the data is the same. 
* If the copied object is deleted, we trigger an event on its source object to make sure that all copies are synced 
* If we clean up the undesired copies each time we trigger an event on the source 
* If the source is deleted, all the copies will be deleted 

The PR introduces an interface called SyncableObject to avoid duplicating the code for configmaps and secrets. Since the code is more complicated, we avoid duplication. 

Fixes #28 