### PR TITLE
Copied Objects: E2E for DataSyncer controller

### DIFF
--- a/pkg/test/e2e/datasyncer/datasyncer_e2e_test.go
+++ b/pkg/test/e2e/datasyncer/datasyncer_e2e_test.go
@@ -262,11 +262,12 @@ var _ = Describe("Copy Deleted", func() {
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: challengeName}, &copy)).To(Succeed())
 		Expect(k8sClient.Delete(ctx, &copy)).To(Succeed())
 
-		By("waiting for the copy to be fully removed")
-		Eventually(func() bool {
-			var sec corev1.Secret
-			return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: challengeName}, &sec))
-		}, timeout, interval).Should(BeTrue())
+		// Note: We don't want to wait for the copy to be fully removed before checking for recreation, because if the controller is working correctly it may never actually be fully removed (it may be recreated faster than we can observe the deletion). Instead, we can directly check for the presence of the copy after deletion, and if the controller is working it should be present again very quickly.
+		// By("waiting for the copy to be fully removed")
+		// Eventually(func() bool {
+		// 	var sec corev1.Secret
+		// 	return apierrors.IsNotFound(k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: challengeName}, &sec))
+		// }, timeout, interval).Should(BeTrue())
 
 		By("verifying the controller recreates the copy")
 		Eventually(func() error {


### PR DESCRIPTION
This PR improves the e2e tests for the datasyncer controller by testing: 
* changing the copy's data directly 
* deletes the copy while the source is alive 
* removes one of two target namespaces from the annotation 
* deletes the source secret 

Fixes #33 