### PR TITLE
Add validation and mutation webhooks for ChallengeInstance CRD

### DIFF
--- a/cmd/webhook/app/app.go
+++ b/cmd/webhook/app/app.go
@@ -29,6 +29,8 @@ import (
 
 	challengemutation "github.com/kubeflag/kubeflag/pkg/webhook/challenge/mutation"
 	challengevalidation "github.com/kubeflag/kubeflag/pkg/webhook/challenge/validation"
+	challengeinstancemutation "github.com/kubeflag/kubeflag/pkg/webhook/challengeinstance/mutation"
+	challengeinstancevalidation "github.com/kubeflag/kubeflag/pkg/webhook/challengeinstance/validation"
 	consumervalidation "github.com/kubeflag/kubeflag/pkg/webhook/consumer/validation"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -127,8 +129,17 @@ func runWebhookManager(opts *options.WebhookServerRunOptions) error {
 		return err
 	}
 
+	// challengeinstance validation webhook
+	if err := challengeinstancevalidation.Add(mgr, log); err != nil {
+		log.Error(err, "Failed to setup challengeinstance validation webhook")
+		return err
+	}
+
 	// mutation cannot, because we require separate defaulting for CREATE and UPDATE operations
 	challengemutation.NewAdmissionHanlder(&log, mgr.GetScheme(), mgr.GetClient(), caPool).SetupWebhookWithManager(mgr)
+
+	// challengeinstance mutation webhook (CREATE-only defaulting)
+	challengeinstancemutation.NewAdmissionHandler(&log, mgr.GetScheme(), mgr.GetClient()).SetupWebhookWithManager(mgr)
 	log.Info("Registered endpoints", "endpoints", mgr.GetWebhookServer())
 
 	log.Info("Starting the webhook...")

--- a/config/deploy/challengeinstance_webhookconfiguration.yaml
+++ b/config/deploy/challengeinstance_webhookconfiguration.yaml
@@ -1,0 +1,51 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kubeflag-challengeinstance-validating
+webhooks:
+  - name: vchallengeinstance.kubeflag.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      service:
+        name: kubeflag-webhook-service
+        namespace: kubeflag-system
+        path: /validate-kubeflag-io-v1alpha1-challengeinstance
+        port: 443
+      caBundle: <BASE64_ENCODED_CA_BUNDLE>
+    rules:
+      - apiGroups: ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["challengeinstances"]
+        scope: "*"
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubeflag-challengeinstance-mutating
+webhooks:
+  - name: mchallengeinstance.kubeflag.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      service:
+        name: kubeflag-webhook-service
+        namespace: kubeflag-system
+        path: /mutate-challengeinstance-v1
+        port: 443
+      caBundle: <BASE64_ENCODED_CA_BUNDLE>
+    rules:
+      - apiGroups: ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources: ["challengeinstances"]
+        scope: "*"

--- a/hack/run-webhook-kind.sh
+++ b/hack/run-webhook-kind.sh
@@ -209,6 +209,48 @@ webhooks:
         operations:  ["CREATE", "UPDATE"]
         resources:   ["challenges"]
         scope:       "*"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kubeflag-challengeinstance-validating
+webhooks:
+  - name: vchallengeinstance.kubeflag.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      url: "https://${HOST_IP}:${WEBHOOK_PORT}/validate-kubeflag-io-v1alpha1-challengeinstance"
+      caBundle: ${CA_BUNDLE}
+    rules:
+      - apiGroups:   ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["challengeinstances"]
+        scope:       "*"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubeflag-challengeinstance-mutating
+webhooks:
+  - name: mchallengeinstance.kubeflag.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      url: "https://${HOST_IP}:${WEBHOOK_PORT}/mutate-challengeinstance-v1"
+      caBundle: ${CA_BUNDLE}
+    rules:
+      - apiGroups:   ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE"]
+        resources:   ["challengeinstances"]
+        scope:       "*"
 EOF
 info "ValidatingWebhookConfiguration and MutatingWebhookConfiguration applied."
 info "Webhook URL: https://${HOST_IP}:${WEBHOOK_PORT}"

--- a/pkg/webhook/challengeinstance/mutation/handler.go
+++ b/pkg/webhook/challengeinstance/mutation/handler.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating KubeFlag ChallengeInstance CRD.
+type AdmissionHandler struct {
+	log     *logr.Logger
+	decoder admission.Decoder
+	client  ctrlruntimeclient.Client
+}
+
+// NewAdmissionHandler returns a new ChallengeInstance AdmissionHandler.
+func NewAdmissionHandler(log *logr.Logger, scheme *runtime.Scheme, client ctrlruntimeclient.Client) *AdmissionHandler {
+	return &AdmissionHandler{
+		log:     log,
+		decoder: admission.NewDecoder(scheme),
+		client:  client,
+	}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-challengeinstance-v1", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	instance := &kubeflagv1.ChallengeInstance{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, instance); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+	case admissionv1.Update, admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on challengeinstance resources", req.Operation))
+	}
+
+	mutator := NewMutator(h.client)
+
+	mutated, mutateErr := mutator.Mutate(ctx, instance)
+	if mutateErr != nil {
+		h.log.Error(mutateErr, "challengeinstance mutation failed")
+
+		status := http.StatusBadRequest
+		if mutateErr.Type == field.ErrorTypeInternal {
+			status = http.StatusInternalServerError
+		}
+
+		return webhook.Errored(int32(status), mutateErr)
+	}
+
+	mutatedInstance, err := json.Marshal(mutated)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling challengeinstance object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedInstance)
+}

--- a/pkg/webhook/challengeinstance/mutation/mutator.go
+++ b/pkg/webhook/challengeinstance/mutation/mutator.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"fmt"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Mutator for mutating KubeFlag ChallengeInstance CRD.
+type Mutator struct {
+	client ctrlruntimeclient.Client
+}
+
+// NewMutator returns a new ChallengeInstance Mutator.
+func NewMutator(client ctrlruntimeclient.Client) *Mutator {
+	return &Mutator{
+		client: client,
+	}
+}
+
+func (m *Mutator) Mutate(ctx context.Context, instance *kubeflagv1.ChallengeInstance) (*kubeflagv1.ChallengeInstance, *field.Error) {
+	// Do not perform mutations on instances in deletion.
+	if instance.DeletionTimestamp != nil {
+		return instance, nil
+	}
+
+	// Look up the referenced Challenge to get defaults.
+	challenge := &kubeflagv1.Challenge{}
+	if err := m.client.Get(ctx, types.NamespacedName{Name: instance.Spec.ChallengeRef}, challenge); err != nil {
+		return nil, field.InternalError(
+			field.NewPath("spec", "challengeRef"),
+			fmt.Errorf("failed to look up Challenge %q: %w", instance.Spec.ChallengeRef, err),
+		)
+	}
+
+	// Default TTL from the Challenge's DefaultTTL if not set.
+	if instance.Spec.TTL == nil && challenge.Spec.DefaultTTL != nil {
+		defaultTTL := *challenge.Spec.DefaultTTL
+		instance.Spec.TTL = &defaultTTL
+	}
+
+	// Set the challengeRef label.
+	if instance.Labels == nil {
+		instance.Labels = make(map[string]string)
+	}
+	instance.Labels["challengeRef"] = instance.Spec.ChallengeRef
+
+	return instance, nil
+}

--- a/pkg/webhook/challengeinstance/mutation/mutator_test.go
+++ b/pkg/webhook/challengeinstance/mutation/mutator_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = kubeflagv1.AddToScheme(scheme)
+	return scheme
+}
+
+func durationPtr(d time.Duration) *metav1.Duration {
+	return &metav1.Duration{Duration: d}
+}
+
+func challengeWithTTL(name string, ttl *metav1.Duration) *kubeflagv1.Challenge {
+	return &kubeflagv1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       kubeflagv1.ChallengeSpec{DefaultTTL: ttl},
+		Status:     kubeflagv1.ChallengeStatus{Healthy: true},
+	}
+}
+
+func TestMutate_DefaultsTTLFromChallenge(t *testing.T) {
+	scheme := newScheme()
+	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+
+	instance := &kubeflagv1.ChallengeInstance{
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "web-challenge",
+			User:         "player1",
+			// TTL is nil — should be defaulted
+		},
+	}
+
+	m := NewMutator(client)
+	mutated, err := m.Mutate(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Spec.TTL == nil {
+		t.Fatal("expected TTL to be defaulted, got nil")
+	}
+	if mutated.Spec.TTL.Duration != 15*time.Minute {
+		t.Errorf("expected TTL 15m, got %v", mutated.Spec.TTL.Duration)
+	}
+}
+
+func TestMutate_PreservesExistingTTL(t *testing.T) {
+	scheme := newScheme()
+	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+
+	instance := &kubeflagv1.ChallengeInstance{
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "web-challenge",
+			User:         "player1",
+			TTL:          durationPtr(30 * time.Minute),
+		},
+	}
+
+	m := NewMutator(client)
+	mutated, err := m.Mutate(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Spec.TTL.Duration != 30*time.Minute {
+		t.Errorf("expected TTL to remain 30m, got %v", mutated.Spec.TTL.Duration)
+	}
+}
+
+func TestMutate_InjectsChallengeRefLabel(t *testing.T) {
+	scheme := newScheme()
+	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+
+	instance := &kubeflagv1.ChallengeInstance{
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "web-challenge",
+			User:         "player1",
+			TTL:          durationPtr(10 * time.Minute),
+		},
+	}
+
+	m := NewMutator(client)
+	mutated, err := m.Mutate(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	val, ok := mutated.Labels["challengeRef"]
+	if !ok {
+		t.Fatal("expected challengeRef label to be set")
+	}
+	if val != "web-challenge" {
+		t.Errorf("expected label value %q, got %q", "web-challenge", val)
+	}
+}
+
+func TestMutate_PreservesExistingLabels(t *testing.T) {
+	scheme := newScheme()
+	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
+	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+
+	instance := &kubeflagv1.ChallengeInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"team": "blue",
+			},
+		},
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "web-challenge",
+			User:         "player1",
+			TTL:          durationPtr(10 * time.Minute),
+		},
+	}
+
+	m := NewMutator(client)
+	mutated, err := m.Mutate(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Labels["team"] != "blue" {
+		t.Errorf("expected existing label 'team=blue' to be preserved, got %q", mutated.Labels["team"])
+	}
+	if mutated.Labels["challengeRef"] != "web-challenge" {
+		t.Errorf("expected challengeRef label to be injected, got %q", mutated.Labels["challengeRef"])
+	}
+}
+
+func TestMutate_ChallengeNotFound(t *testing.T) {
+	scheme := newScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build() // no challenge in store
+
+	instance := &kubeflagv1.ChallengeInstance{
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "does-not-exist",
+			User:         "player1",
+		},
+	}
+
+	m := NewMutator(client)
+	_, err := m.Mutate(context.Background(), instance)
+	if err == nil {
+		t.Fatal("expected error when Challenge does not exist, got nil")
+	}
+}
+
+func TestMutate_SkipsWhenDeletionTimestampSet(t *testing.T) {
+	scheme := newScheme()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build() // no challenge needed
+
+	now := metav1.Now()
+	instance := &kubeflagv1.ChallengeInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubeflag.io/cleanup-instance"}, // required for non-zero DeletionTimestamp
+		},
+		Spec: kubeflagv1.ChallengeInstanceSpec{
+			ChallengeRef: "web-challenge",
+			User:         "player1",
+		},
+	}
+
+	m := NewMutator(client)
+	mutated, err := m.Mutate(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return as-is — no TTL defaulted, no label set
+	if mutated.Spec.TTL != nil {
+		t.Errorf("expected TTL to remain nil for deleting instance, got %v", mutated.Spec.TTL)
+	}
+	if _, ok := mutated.Labels["challengeRef"]; ok {
+		t.Error("expected no challengeRef label for deleting instance")
+	}
+}

--- a/pkg/webhook/challengeinstance/mutation/mutator_test.go
+++ b/pkg/webhook/challengeinstance/mutation/mutator_test.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func newScheme() *runtime.Scheme {
@@ -49,7 +49,7 @@ func challengeWithTTL(name string, ttl *metav1.Duration) *kubeflagv1.Challenge {
 func TestMutate_DefaultsTTLFromChallenge(t *testing.T) {
 	scheme := newScheme()
 	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
 
 	instance := &kubeflagv1.ChallengeInstance{
 		Spec: kubeflagv1.ChallengeInstanceSpec{
@@ -75,7 +75,7 @@ func TestMutate_DefaultsTTLFromChallenge(t *testing.T) {
 func TestMutate_PreservesExistingTTL(t *testing.T) {
 	scheme := newScheme()
 	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
 
 	instance := &kubeflagv1.ChallengeInstance{
 		Spec: kubeflagv1.ChallengeInstanceSpec{
@@ -98,7 +98,7 @@ func TestMutate_PreservesExistingTTL(t *testing.T) {
 func TestMutate_InjectsChallengeRefLabel(t *testing.T) {
 	scheme := newScheme()
 	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
 
 	instance := &kubeflagv1.ChallengeInstance{
 		Spec: kubeflagv1.ChallengeInstanceSpec{
@@ -125,7 +125,7 @@ func TestMutate_InjectsChallengeRefLabel(t *testing.T) {
 func TestMutate_PreservesExistingLabels(t *testing.T) {
 	scheme := newScheme()
 	challenge := challengeWithTTL("web-challenge", durationPtr(15*time.Minute))
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(challenge).Build()
 
 	instance := &kubeflagv1.ChallengeInstance{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ func TestMutate_PreservesExistingLabels(t *testing.T) {
 
 func TestMutate_ChallengeNotFound(t *testing.T) {
 	scheme := newScheme()
-	client := fake.NewClientBuilder().WithScheme(scheme).Build() // no challenge in store
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).Build() // no challenge in store
 
 	instance := &kubeflagv1.ChallengeInstance{
 		Spec: kubeflagv1.ChallengeInstanceSpec{
@@ -173,7 +173,7 @@ func TestMutate_ChallengeNotFound(t *testing.T) {
 
 func TestMutate_SkipsWhenDeletionTimestampSet(t *testing.T) {
 	scheme := newScheme()
-	client := fake.NewClientBuilder().WithScheme(scheme).Build() // no challenge needed
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).Build() // no challenge needed
 
 	now := metav1.Now()
 	instance := &kubeflagv1.ChallengeInstance{

--- a/pkg/webhook/challengeinstance/validation/validation.go
+++ b/pkg/webhook/challengeinstance/validation/validation.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type validator struct {
+	client ctrlruntimeclient.Client
+}
+
+func NewValidator(client ctrlruntimeclient.Client) *validator {
+	return &validator{client: client}
+}
+
+var _ admission.CustomValidator = &validator{}
+
+// Add registers the ChallengeInstance validation webhook with the manager.
+func Add(mgr manager.Manager, log logr.Logger) error {
+	if err := builder.WebhookManagedBy(mgr).
+		For(&kubeflagv1.ChallengeInstance{}).
+		WithValidator(NewValidator(mgr.GetClient())).
+		Complete(); err != nil {
+		log.Error(err, "Failed to setup ChallengeInstance validation webhook")
+		return err
+	}
+
+	log.Info("ChallengeInstance validation webhook registered")
+	return nil
+}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	instance, ok := obj.(*kubeflagv1.ChallengeInstance)
+	if !ok {
+		return nil, errors.New("object is not a ChallengeInstance")
+	}
+
+	var allErrs field.ErrorList
+
+	challengeRefPath := field.NewPath("spec", "challengeRef")
+	userPath := field.NewPath("spec", "user")
+	ttlPath := field.NewPath("spec", "ttl")
+
+	// challengeRef must not be empty.
+	if instance.Spec.ChallengeRef == "" {
+		allErrs = append(allErrs, field.Required(challengeRefPath, "challengeRef must be set"))
+		return nil, allErrs.ToAggregate()
+	}
+
+	// challengeRef must reference an existing Challenge that is healthy.
+	if err := v.validateChallengeRef(ctx, instance.Spec.ChallengeRef, challengeRefPath, &allErrs); err != nil {
+		return nil, err
+	}
+
+	// user must not be empty.
+	if instance.Spec.User == "" {
+		allErrs = append(allErrs, field.Required(userPath, "user must be set"))
+	} else {
+		// user must be DNS-compatible (combined <challenge>-<user> becomes a Deployment name).
+		if errs := k8svalidation.IsDNS1123Label(instance.Spec.User); len(errs) != 0 {
+			allErrs = append(allErrs, field.Invalid(
+				userPath,
+				instance.Spec.User,
+				fmt.Sprintf("user must be a valid DNS label: %s", strings.Join(errs, ", ")),
+			))
+		}
+	}
+
+	// ttl, if set, must be positive.
+	if instance.Spec.TTL != nil && instance.Spec.TTL.Duration <= 0 {
+		allErrs = append(allErrs, field.Invalid(
+			ttlPath,
+			instance.Spec.TTL.Duration.String(),
+			"ttl must be a positive duration",
+		))
+	}
+
+	return nil, allErrs.ToAggregate()
+}
+
+func (v *validator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldInstance, ok := oldObj.(*kubeflagv1.ChallengeInstance)
+	if !ok {
+		return nil, errors.New("old object is not a ChallengeInstance")
+	}
+	newInstance, ok := newObj.(*kubeflagv1.ChallengeInstance)
+	if !ok {
+		return nil, errors.New("new object is not a ChallengeInstance")
+	}
+
+	var allErrs field.ErrorList
+
+	challengeRefPath := field.NewPath("spec", "challengeRef")
+	userPath := field.NewPath("spec", "user")
+
+	// challengeRef is immutable after creation.
+	if oldInstance.Spec.ChallengeRef != newInstance.Spec.ChallengeRef {
+		allErrs = append(allErrs, field.Forbidden(
+			challengeRefPath,
+			fmt.Sprintf("challengeRef is immutable: cannot change from %q to %q",
+				oldInstance.Spec.ChallengeRef, newInstance.Spec.ChallengeRef),
+		))
+	}
+
+	// user is immutable after creation.
+	if oldInstance.Spec.User != newInstance.Spec.User {
+		allErrs = append(allErrs, field.Forbidden(
+			userPath,
+			fmt.Sprintf("user is immutable: cannot change from %q to %q",
+				oldInstance.Spec.User, newInstance.Spec.User),
+		))
+	}
+
+	return nil, allErrs.ToAggregate()
+}
+
+func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateChallengeRef checks that the referenced Challenge exists and is healthy.
+// Returns a non-nil error only when there is an unexpected internal failure.
+func (v *validator) validateChallengeRef(ctx context.Context, challengeRef string, path *field.Path, allErrs *field.ErrorList) error {
+	challenge := &kubeflagv1.Challenge{}
+	err := v.client.Get(ctx, types.NamespacedName{Name: challengeRef}, challenge)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			*allErrs = append(*allErrs, field.NotFound(path, fmt.Sprintf("Challenge %q does not exist", challengeRef)))
+			return nil
+		}
+		return fmt.Errorf("error looking up Challenge %q: %w", challengeRef, err)
+	}
+
+	if !challenge.Status.Healthy {
+		*allErrs = append(*allErrs, field.Forbidden(path, fmt.Sprintf("Challenge %q is not healthy", challengeRef)))
+	}
+
+	return nil
+}

--- a/pkg/webhook/challengeinstance/validation/validation_test.go
+++ b/pkg/webhook/challengeinstance/validation/validation_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newScheme returns a scheme with kubeflagv1 types registered.
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = kubeflagv1.AddToScheme(scheme)
+	return scheme
+}
+
+// healthyChallenge returns a Challenge with status.healthy=true.
+func healthyChallenge(name string) *kubeflagv1.Challenge {
+	return &kubeflagv1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     kubeflagv1.ChallengeStatus{Healthy: true},
+	}
+}
+
+// unhealthyChallenge returns a Challenge with status.healthy=false.
+func unhealthyChallenge(name string) *kubeflagv1.Challenge {
+	return &kubeflagv1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     kubeflagv1.ChallengeStatus{Healthy: false},
+	}
+}
+
+// durationPtr returns a pointer to a metav1.Duration.
+func durationPtr(d time.Duration) *metav1.Duration {
+	return &metav1.Duration{Duration: d}
+}
+
+func TestValidateCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		instance  *kubeflagv1.ChallengeInstance
+		objects   []runtime.Object
+		expectErr bool
+	}{
+		{
+			name: "valid instance with TTL",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+					TTL:          durationPtr(10 * time.Minute),
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: false,
+		},
+		{
+			name: "valid instance without TTL (nil)",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: false,
+		},
+		{
+			name: "empty challengeRef",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "",
+					User:         "player1",
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "challengeRef references non-existent Challenge",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "does-not-exist",
+					User:         "player1",
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "referenced Challenge is not healthy",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "broken-challenge",
+					User:         "player1",
+				},
+			},
+			objects:   []runtime.Object{unhealthyChallenge("broken-challenge")},
+			expectErr: true,
+		},
+		{
+			name: "empty user",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "",
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: true,
+		},
+		{
+			name: "invalid user (not DNS-compatible)",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "INVALID_USER!",
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: true,
+		},
+		{
+			name: "negative TTL",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+					TTL:          durationPtr(-5 * time.Minute),
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: true,
+		},
+		{
+			name: "zero TTL",
+			instance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+					TTL:          durationPtr(0),
+				},
+			},
+			objects:   []runtime.Object{healthyChallenge("web-challenge")},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			for _, obj := range tt.objects {
+				clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+			}
+			client := clientBuilder.Build()
+
+			v := NewValidator(client)
+			_, err := v.ValidateCreate(context.Background(), tt.instance)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		oldInstance *kubeflagv1.ChallengeInstance
+		newInstance *kubeflagv1.ChallengeInstance
+		expectErr   bool
+	}{
+		{
+			name: "no changes",
+			oldInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+				},
+			},
+			newInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "changed challengeRef",
+			oldInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+				},
+			},
+			newInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "another-challenge",
+					User:         "player1",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "changed user",
+			oldInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+				},
+			},
+			newInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player2",
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "TTL change is allowed",
+			oldInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+					TTL:          durationPtr(10 * time.Minute),
+				},
+			},
+			newInstance: &kubeflagv1.ChallengeInstance{
+				Spec: kubeflagv1.ChallengeInstanceSpec{
+					ChallengeRef: "web-challenge",
+					User:         "player1",
+					TTL:          durationPtr(30 * time.Minute),
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			v := NewValidator(client)
+			_, err := v.ValidateUpdate(context.Background(), tt.oldInstance, tt.newInstance)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/webhook/challengeinstance/validation/validation_test.go
+++ b/pkg/webhook/challengeinstance/validation/validation_test.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // newScheme returns a scheme with kubeflagv1 types registered.
@@ -170,7 +170,7 @@ func TestValidateCreate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scheme := newScheme()
-			clientBuilder := fake.NewClientBuilder().WithScheme(scheme)
+			clientBuilder := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme)
 			for _, obj := range tt.objects {
 				clientBuilder = clientBuilder.WithRuntimeObjects(obj)
 			}
@@ -267,7 +267,7 @@ func TestValidateUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scheme := newScheme()
-			client := fake.NewClientBuilder().WithScheme(scheme).Build()
+			client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).Build()
 
 			v := NewValidator(client)
 			_, err := v.ValidateUpdate(context.Background(), tt.oldInstance, tt.newInstance)


### PR DESCRIPTION
## Summary

The ChallengeInstance CRD currently has zero admission webhooks — all validation happens at reconcile time in the controller, which causes a nil-pointer crash when TTL is nil, silently skips unhealthy challenges with no user feedback, and wastefully re-applies the challengeRef label on every reconcile loop. This PR adds a validating admission webhook (CREATE + UPDATE) and a mutating admission webhook (CREATE only) for ChallengeInstance, shifting validation to admission time so users get immediate, clear errors and the controller can reconcile safely.

## Acceptance Criteria

 #### Validation (CREATE)
- [ ] `challengeRef` must not be empty
- [ ] `challengeRef` must reference an existing Challenge
- [ ] Referenced Challenge must have `status.healthy == true`
- [ ] `user` must not be empty
- [ ] `user` must be DNS-compatible (RFC 1123 label)
- [ ] `ttl`, if set, must be a positive duration
 
 #### Validation (UPDATE)
- [ ] `challengeRef` is immutable
- [ ] `user` is immutable

#### Mutation (CREATE)
- [ ] Defaults `ttl` from `challenge.Spec.DefaultTTL` when not set
- [ ] Preserves `ttl` when explicitly provided
- [ ] Sets `challengeRef` label on the instance
- [ ] Preserves existing labels (does not clobber)
- [ ] Skips mutation when `DeletionTimestamp` is set

#### Tests
- [ ] All 13 validation unit tests pass
- [ ] All 6 mutation unit tests pass
- [ ] `go build ./...` succeeds
- [ ] `go vet ./...` clean