### PR TITLE
Add validation and mutation webhooks for tenant

### DIFF
--- a/cmd/webhook/app/app.go
+++ b/cmd/webhook/app/app.go
@@ -30,6 +30,8 @@ import (
 	challengemutation "github.com/kubeflag/kubeflag/pkg/webhook/challenge/mutation"
 	challengevalidation "github.com/kubeflag/kubeflag/pkg/webhook/challenge/validation"
 	consumervalidation "github.com/kubeflag/kubeflag/pkg/webhook/consumer/validation"
+	tenantmutation "github.com/kubeflag/kubeflag/pkg/webhook/tenant/mutation"
+	tenantvalidation "github.com/kubeflag/kubeflag/pkg/webhook/tenant/validation"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -127,8 +129,17 @@ func runWebhookManager(opts *options.WebhookServerRunOptions) error {
 		return err
 	}
 
+	// tenant validation webhook
+	if err := tenantvalidation.Add(mgr, log); err != nil {
+		log.Error(err, "Failed to setup tenant validation webhook")
+		return err
+	}
+
 	// mutation cannot, because we require separate defaulting for CREATE and UPDATE operations
 	challengemutation.NewAdmissionHanlder(&log, mgr.GetScheme(), mgr.GetClient(), caPool).SetupWebhookWithManager(mgr)
+
+	// tenant mutation webhook (CREATE-only defaulting)
+	tenantmutation.NewAdmissionHandler(&log, mgr.GetScheme()).SetupWebhookWithManager(mgr)
 	log.Info("Registered endpoints", "endpoints", mgr.GetWebhookServer())
 
 	log.Info("Starting the webhook...")

--- a/config/deploy/tenant_webhookconfiguration.yaml
+++ b/config/deploy/tenant_webhookconfiguration.yaml
@@ -1,0 +1,51 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kubeflag-tenant-validating
+webhooks:
+  - name: vtenant.kubeflag.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      service:
+        name: kubeflag-webhook-service
+        namespace: kubeflag-system
+        path: /validate-kubeflag-io-v1alpha1-tenant
+        port: 443
+      caBundle: <BASE64_ENCODED_CA_BUNDLE>
+    rules:
+      - apiGroups: ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["tenants"]
+        scope: "*"
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubeflag-tenant-mutating
+webhooks:
+  - name: mtenant.kubeflag.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      service:
+        name: kubeflag-webhook-service
+        namespace: kubeflag-system
+        path: /mutate-tenant-v1
+        port: 443
+      caBundle: <BASE64_ENCODED_CA_BUNDLE>
+    rules:
+      - apiGroups: ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE"]
+        resources: ["tenants"]
+        scope: "*"

--- a/hack/run-webhook-kind.sh
+++ b/hack/run-webhook-kind.sh
@@ -209,6 +209,48 @@ webhooks:
         operations:  ["CREATE", "UPDATE"]
         resources:   ["challenges"]
         scope:       "*"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kubeflag-tenant-validating
+webhooks:
+  - name: vtenant.kubeflag.io
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      url: "https://${HOST_IP}:${WEBHOOK_PORT}/validate-kubeflag-io-v1alpha1-tenant"
+      caBundle: ${CA_BUNDLE}
+    rules:
+      - apiGroups:   ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["tenants"]
+        scope:       "*"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kubeflag-tenant-mutating
+webhooks:
+  - name: mtenant.kubeflag.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    timeoutSeconds: 10
+    matchPolicy: Equivalent
+    clientConfig:
+      url: "https://${HOST_IP}:${WEBHOOK_PORT}/mutate-tenant-v1"
+      caBundle: ${CA_BUNDLE}
+    rules:
+      - apiGroups:   ["kubeflag.io"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE"]
+        resources:   ["tenants"]
+        scope:       "*"
 EOF
 info "ValidatingWebhookConfiguration and MutatingWebhookConfiguration applied."
 info "Webhook URL: https://${HOST_IP}:${WEBHOOK_PORT}"

--- a/pkg/webhook/tenant/mutation/handler.go
+++ b/pkg/webhook/tenant/mutation/handler.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating KubeFlag Tenant CRD.
+type AdmissionHandler struct {
+	log     *logr.Logger
+	decoder admission.Decoder
+}
+
+// NewAdmissionHandler returns a new Tenant AdmissionHandler.
+func NewAdmissionHandler(log *logr.Logger, scheme *runtime.Scheme) *AdmissionHandler {
+	return &AdmissionHandler{
+		log:     log,
+		decoder: admission.NewDecoder(scheme),
+	}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-tenant-v1", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	tenant := &kubeflagv1.Tenant{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, tenant); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+	case admissionv1.Update, admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on tenant resources", req.Operation))
+	}
+
+	mutator := NewMutator()
+
+	mutated, mutateErr := mutator.Mutate(ctx, tenant)
+	if mutateErr != nil {
+		h.log.Error(mutateErr, "tenant mutation failed")
+
+		status := http.StatusBadRequest
+		if mutateErr.Type == field.ErrorTypeInternal {
+			status = http.StatusInternalServerError
+		}
+
+		return webhook.Errored(int32(status), mutateErr)
+	}
+
+	mutatedTenant, err := json.Marshal(mutated)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling tenant object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedTenant)
+}

--- a/pkg/webhook/tenant/mutation/mutator.go
+++ b/pkg/webhook/tenant/mutation/mutator.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// Mutator for mutating KubeFlag Tenant CRD.
+type Mutator struct{}
+
+// NewMutator returns a new Tenant Mutator.
+func NewMutator() *Mutator {
+	return &Mutator{}
+}
+
+func (m *Mutator) Mutate(_ context.Context, tenant *kubeflagv1.Tenant) (*kubeflagv1.Tenant, *field.Error) {
+	// Do not perform mutations on tenants in deletion.
+	if tenant.DeletionTimestamp != nil {
+		return tenant, nil
+	}
+
+	// Default displayName to metadata.name if not set.
+	if tenant.Spec.DisplayName == "" {
+		tenant.Spec.DisplayName = tenant.Name
+	}
+
+	return tenant, nil
+}

--- a/pkg/webhook/tenant/mutation/mutator_test.go
+++ b/pkg/webhook/tenant/mutation/mutator_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"testing"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMutate_DefaultsDisplayName(t *testing.T) {
+	tenant := &kubeflagv1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+		Spec: kubeflagv1.TenantSpec{
+			DisplayName: "", // empty — should be defaulted
+		},
+	}
+
+	m := NewMutator()
+	mutated, err := m.Mutate(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Spec.DisplayName != "my-tenant" {
+		t.Errorf("expected displayName %q, got %q", "my-tenant", mutated.Spec.DisplayName)
+	}
+}
+
+func TestMutate_PreservesExistingDisplayName(t *testing.T) {
+	tenant := &kubeflagv1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+		Spec: kubeflagv1.TenantSpec{
+			DisplayName: "My Custom Name",
+		},
+	}
+
+	m := NewMutator()
+	mutated, err := m.Mutate(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Spec.DisplayName != "My Custom Name" {
+		t.Errorf("expected displayName %q, got %q", "My Custom Name", mutated.Spec.DisplayName)
+	}
+}
+
+func TestMutate_SkipsWhenDeletionTimestampSet(t *testing.T) {
+	now := metav1.Now()
+	tenant := &kubeflagv1.Tenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-tenant",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubeflag.io/cleanup"},
+		},
+		Spec: kubeflagv1.TenantSpec{
+			DisplayName: "", // should NOT be defaulted
+		},
+	}
+
+	m := NewMutator()
+	mutated, err := m.Mutate(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mutated.Spec.DisplayName != "" {
+		t.Errorf("expected displayName to remain empty for deleting tenant, got %q", mutated.Spec.DisplayName)
+	}
+}

--- a/pkg/webhook/tenant/validation/validation.go
+++ b/pkg/webhook/tenant/validation/validation.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type validator struct {
+	client ctrlruntimeclient.Client
+}
+
+func NewValidator(client ctrlruntimeclient.Client) *validator {
+	return &validator{client: client}
+}
+
+var _ admission.CustomValidator = &validator{}
+
+// Add registers the Tenant validation webhook with the manager.
+func Add(mgr manager.Manager, log logr.Logger) error {
+	if err := builder.WebhookManagedBy(mgr).
+		For(&kubeflagv1.Tenant{}).
+		WithValidator(NewValidator(mgr.GetClient())).
+		Complete(); err != nil {
+		log.Error(err, "Failed to setup Tenant validation webhook")
+		return err
+	}
+
+	log.Info("Tenant validation webhook registered")
+	return nil
+}
+
+func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	tenant, ok := obj.(*kubeflagv1.Tenant)
+	if !ok {
+		return nil, errors.New("object is not a Tenant")
+	}
+
+	var allErrs field.ErrorList
+
+	// Name must be a valid DNS label (RFC 1035).
+	if errs := k8svalidation.IsDNS1035Label(tenant.Name); len(errs) != 0 {
+		return nil, fmt.Errorf("tenant name must be a valid RFC 1035 label: %s", strings.Join(errs, ", "))
+	}
+
+	// Validate rejectedConsumers.
+	if errs := v.validateRejectedConsumers(ctx, tenant.Spec.RejectedConsumers); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return nil, allErrs.ToAggregate()
+}
+
+func (v *validator) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	newTenant, ok := newObj.(*kubeflagv1.Tenant)
+	if !ok {
+		return nil, errors.New("new object is not a Tenant")
+	}
+
+	var allErrs field.ErrorList
+
+	// Validate rejectedConsumers.
+	if errs := v.validateRejectedConsumers(ctx, newTenant.Spec.RejectedConsumers); len(errs) > 0 {
+		allErrs = append(allErrs, errs...)
+	}
+
+	return nil, allErrs.ToAggregate()
+}
+
+func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateRejectedConsumers checks that entries are non-empty, unique, and reference existing Consumers.
+func (v *validator) validateRejectedConsumers(ctx context.Context, consumers []string) field.ErrorList {
+	var allErrs field.ErrorList
+	basePath := field.NewPath("spec", "rejectedConsumers")
+
+	seen := make(map[string]struct{})
+	for i, name := range consumers {
+		idxPath := basePath.Index(i)
+
+		// Must not be empty.
+		if name == "" {
+			allErrs = append(allErrs, field.Required(idxPath, "consumer name must not be empty"))
+			continue
+		}
+
+		// Must not be duplicate.
+		if _, exists := seen[name]; exists {
+			allErrs = append(allErrs, field.Duplicate(idxPath, name))
+			continue
+		}
+		seen[name] = struct{}{}
+
+		// Must reference an existing Consumer.
+		consumer := &kubeflagv1.Consumer{}
+		err := v.client.Get(ctx, types.NamespacedName{Name: name}, consumer)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				allErrs = append(allErrs, field.NotFound(idxPath, fmt.Sprintf("Consumer %q does not exist", name)))
+			} else {
+				allErrs = append(allErrs, field.InternalError(idxPath, fmt.Errorf("error looking up Consumer %q: %w", name, err)))
+			}
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/webhook/tenant/validation/validation_test.go
+++ b/pkg/webhook/tenant/validation/validation_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The KubeFlag Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"testing"
+
+	kubeflagv1 "github.com/kubeflag/kubeflag/pkg/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = kubeflagv1.AddToScheme(scheme)
+	return scheme
+}
+
+func existingConsumer(name string) *kubeflagv1.Consumer {
+	return &kubeflagv1.Consumer{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func TestValidateCreate(t *testing.T) {
+	tests := []struct {
+		name      string
+		tenant    *kubeflagv1.Tenant
+		objects   []runtime.Object
+		expectErr bool
+	}{
+		{
+			name: "valid tenant, no rejectedConsumers",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					Policies: kubeflagv1.TenantPolicies{
+						MaxInstancesPerUser: 5,
+						MaxInstancesPerTeam: 10,
+					},
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: false,
+		},
+		{
+			name: "valid tenant with existing rejectedConsumers",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{"bad-consumer"},
+				},
+			},
+			objects:   []runtime.Object{existingConsumer("bad-consumer")},
+			expectErr: false,
+		},
+		{
+			name: "invalid name (not DNS-compatible)",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "INVALID_NAME!"},
+				Spec:       kubeflagv1.TenantSpec{},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "rejectedConsumer references non-existent Consumer",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{"does-not-exist"},
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate entries in rejectedConsumers",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{"consumer-a", "consumer-a"},
+				},
+			},
+			objects:   []runtime.Object{existingConsumer("consumer-a")},
+			expectErr: true,
+		},
+		{
+			name: "empty string in rejectedConsumers",
+			tenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{""},
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			clientBuilder := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme)
+			for _, obj := range tt.objects {
+				clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+			}
+			client := clientBuilder.Build()
+
+			v := NewValidator(client)
+			_, err := v.ValidateCreate(context.Background(), tt.tenant)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldTenant *kubeflagv1.Tenant
+		newTenant *kubeflagv1.Tenant
+		objects   []runtime.Object
+		expectErr bool
+	}{
+		{
+			name: "no changes",
+			oldTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec:       kubeflagv1.TenantSpec{},
+			},
+			newTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec:       kubeflagv1.TenantSpec{},
+			},
+			objects:   []runtime.Object{},
+			expectErr: false,
+		},
+		{
+			name: "rejectedConsumer references non-existent Consumer on update",
+			oldTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec:       kubeflagv1.TenantSpec{},
+			},
+			newTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{"ghost"},
+				},
+			},
+			objects:   []runtime.Object{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate entries in rejectedConsumers on update",
+			oldTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec:       kubeflagv1.TenantSpec{},
+			},
+			newTenant: &kubeflagv1.Tenant{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-tenant"},
+				Spec: kubeflagv1.TenantSpec{
+					RejectedConsumers: []string{"consumer-a", "consumer-a"},
+				},
+			},
+			objects:   []runtime.Object{existingConsumer("consumer-a")},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newScheme()
+			clientBuilder := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme)
+			for _, obj := range tt.objects {
+				clientBuilder = clientBuilder.WithRuntimeObjects(obj)
+			}
+			client := clientBuilder.Build()
+
+			v := NewValidator(client)
+			_, err := v.ValidateUpdate(context.Background(), tt.oldTenant, tt.newTenant)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The Tenant CRD currently has no admission webhooks. This PR adds a validating admission webhook (CREATE + UPDATE) and a mutating admission webhook (CREATE only) for the Tenant CRD — following the same patterns used by the existing Challenge and Consumer webhooks. The validating webhook enforces that the tenant name is DNS-compatible (RFC 1035), and that `rejectedConsumers` entries are non-empty, unique, and reference existing Consumer resources. The mutating webhook defaults `displayName` to `metadata.name` when not set.

**Fixes #42**

## Acceptance Criteria

#### Validation (CREATE)
- [ ] Tenant name must be a valid RFC 1035 DNS label
- [ ] rejectedConsumers entries must not be empty strings
- [ ] rejectedConsumers entries must not contain duplicates
- [ ] rejectedConsumers entries must reference existing Consumers

#### Validation (UPDATE)
- [ ] rejectedConsumers entries must not be empty strings
- [ ] rejectedConsumers entries must not contain duplicates
- [ ] rejectedConsumers entries must reference existing Consumers

#### Mutation (CREATE)
- [ ] Defaults displayName to metadata.name when not set
- [ ] Preserves displayName when explicitly provided
- [ ] Skips mutation when DeletionTimestamp is set

#### Tests
- [ ] All 9 validation unit tests pass (6 CREATE + 3 UPDATE)
- [ ] All 3 mutation unit tests pass
- [ ] go build ./... succeeds
- [ ] go vet ./... clean
